### PR TITLE
Better Entity Details

### DIFF
--- a/webapp/src/components/EntityDetailsBody.tsx
+++ b/webapp/src/components/EntityDetailsBody.tsx
@@ -511,7 +511,7 @@ class EntityDetailsBody extends Component<Props, State> {
         <div className={"flex w-full h-4 " + (this.props.entity.kind === "project" ? "" : colorToBackgroundColorClass(this.props.entity.color))} />
         <div className={"flex w-full h-full flex-row bg-white overflow-auto "}>
 
-          <div className="flex flex-col w-full p-2  ">
+          <div className="max-w-screen-md flex flex-col w-full p-2">
 
             <EntityDetailsAnnotations viewOnly={this.props.viewOnly} open={open} card={this.props.entity} demo={this.props.demo} edit={false} close={() => alert("close")} />
 

--- a/webapp/src/components/EntityDetailsModal.tsx
+++ b/webapp/src/components/EntityDetailsModal.tsx
@@ -57,7 +57,7 @@ class EntityDetailsModal extends Component<Props, State> {
 
       render() {
         return (
-          <div className=" w-full  max-w-5xl   fm-max-dialog  overflow-y-auto ">
+          <div className="m-auto w-full max-w-5xl fm-max-dialog overflow-y-auto">
             <EntityDetailsBody demo={this.props.demo} viewOnly={this.props.viewOnly} url={this.props.url} comments={this.props.comments} entity={this.props.card} close={this.props.close} />
           </div>
         )


### PR DESCRIPTION
* Center EntityDetailsModal horizontally
* Limit width of EntityDetailsBody to 768px to avoid pushing right column out of view and requiring horizontal scrolling

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/1693819/227083273-ddfa9d3e-64e4-4f0e-936d-38b7e83a5cb5.png">
